### PR TITLE
Remove "let doubledNumbers = []" line

### DIFF
--- a/ES6 JavaScript/2_map.md
+++ b/ES6 JavaScript/2_map.md
@@ -4,7 +4,7 @@
 
 ```js
 let numbers = [ 1, 2, 3 ];
-let doubledNumbers = [];
+
 
 let doubled = numbers.map((number) => {
   return number * 2;


### PR DESCRIPTION
In the first example, you can remove `let doubledNumbers = [];` because **map function creates a new array**.